### PR TITLE
Update deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *.log
 node_modules
-test/test.html
+.idea

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-vendor
-.gitignore
-.npmignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,9 @@
 language: node_js
-
+sudo: false
+node_js:
+  - "0.10"
+  - "0.12"
+  - "4"
+  - "5"
+before_install:
+  - npm i -g npm

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,24 @@
+module.exports = function (grunt) {
+
+    grunt.loadNpmTasks("grunt-buster");
+
+    grunt.initConfig({
+        "buster": {
+            "browser": {
+                "test": {
+                    "config-group": "browser"
+                }
+            },
+            "node": {
+                "test": {
+                    "config-group": "node"
+                }
+            }
+        }
+    });
+
+    grunt.registerTask("test", "Clean build, minify and run tests",
+        ["buster:node:test"/*, "buster:browser:server", "buster:browser:phantomjs", "buster:browser:test"*/]
+    );
+
+};

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,7 +18,7 @@ module.exports = function (grunt) {
     });
 
     grunt.registerTask("test", "Clean build, minify and run tests",
-        ["buster:node:test"/*, "buster:browser:server", "buster:browser:phantomjs", "buster:browser:test"*/]
+        ["buster:node:test", "buster:browser:server", "buster:browser:phantomjs", "buster:browser:test"]
     );
 
 };

--- a/buster.js
+++ b/buster.js
@@ -2,7 +2,7 @@ exports["browser"] = {
     environment: "browser",
     libs: [
         "node_modules/when/es6-shim/Promise.js",
-        "node_modules/lodash/dist/lodash.js",
+        "node_modules/lodash/index.js",
         "node_modules/samsam/lib/samsam.js",
         "node_modules/bane/lib/bane.js"
     ],

--- a/buster.js
+++ b/buster.js
@@ -1,4 +1,4 @@
-exports["Browser"] = {
+exports["browser"] = {
 	environment: "browser",
     libs: [
         "node_modules/lodash/dist/lodash.js",
@@ -13,7 +13,7 @@ exports["Browser"] = {
     tests: ["test/*-test.js"]
 };
 
-exports["Node"] = {
+exports["node"] = {
     environment: "node",
     testHelpers: ["test/test-helper.js"],
     tests: ["test/*-test.js"]

--- a/buster.js
+++ b/buster.js
@@ -1,13 +1,14 @@
 exports["browser"] = {
-	environment: "browser",
+    environment: "browser",
     libs: [
+        "node_modules/when/es6-shim/Promise.js",
         "node_modules/lodash/dist/lodash.js",
         "node_modules/samsam/lib/samsam.js",
         "node_modules/bane/lib/bane.js"
     ],
     sources: [
-        "lib/referee.js",
-        "lib/expect.js"
+        "lib/expect.js",
+        "lib/referee.js"
     ],
     testHelpers: ["test/test-helper.js"],
     tests: ["test/*-test.js"]
@@ -15,6 +16,11 @@ exports["browser"] = {
 
 exports["node"] = {
     environment: "node",
-    testHelpers: ["test/test-helper.js"],
-    tests: ["test/*-test.js"]
+    testHelpers: [
+        "node_modules/when/es6-shim/Promise.js",
+        "test/test-helper.js"
+    ],
+    tests: [
+        "test/*-test.js"
+    ]
 };

--- a/lib/referee.js
+++ b/lib/referee.js
@@ -118,17 +118,11 @@
             assertion.apply(null, arguments);
         };
         referee[type][name].test = function () {
-            var deferred = when.defer();
-            var assertion = createAssertion(type, name, func, minArgs, messageValues,
-                function (message) {
-                    deferred.resolve(message);
-                },
-                function (message) {
-                    deferred.reject(message);
-                }
-            );
-            assertion.apply(null, arguments);
-            return deferred.promise;
+            var args = arguments;
+            return new Promise(function (resolve, reject) {
+                var assertion = createAssertion(type, name, func, minArgs, messageValues, resolve, reject);
+                assertion.apply(null, args);
+            });
         };
     }
 

--- a/package.json
+++ b/package.json
@@ -32,10 +32,9 @@
         "test": "grunt test"
     },
     "dependencies": {
-        "lodash": "1.x",
+        "lodash": "3.x",
         "samsam": "1.x",
-        "bane": "1.x",
-        "when": "3.x"
+        "bane": "1.x"
     },
     "devDependencies": {
         "grunt": "0.4.x",
@@ -43,6 +42,7 @@
         "grunt-cli": "0.1.x",
         "buster": "0.7.x",
         "phantomjs": "1.9.x",
-        "sinon": "1.x"
+        "sinon": "1.x",
+        "when": "3.x"
     }
 }

--- a/package.json
+++ b/package.json
@@ -29,19 +29,20 @@
         "url": "https://github.com/busterjs/referee"
     },
     "scripts": {
-        "test": "node node_modules/buster/bin/buster-test --node",
-        "test-debug": "node --debug-brk node_modules/buster/bin/buster-test --node",
-        "start": "node node_modules/buster/bin/buster-server",
-        "test-browser": "node node_modules/buster/bin/buster-test --browser"
+        "test": "grunt test"
     },
     "dependencies": {
-        "lodash": "~1.0",
-        "samsam": "~1.1",
-        "bane": "~1.0",
-        "when": "~3.6"
+        "lodash": "1.x",
+        "samsam": "1.x",
+        "bane": "1.x",
+        "when": "3.x"
     },
     "devDependencies": {
-        "sinon": ">=1.4",
-        "buster": "*"
+        "grunt": "0.4.x",
+        "grunt-buster": "0.4.x",
+        "grunt-cli": "0.1.x",
+        "buster": "0.7.x",
+        "phantomjs": "1.9.x",
+        "sinon": "1.x"
     }
 }

--- a/test/expect-test.js
+++ b/test/expect-test.js
@@ -1,5 +1,5 @@
 /*jslint maxlen:160*/
-(function (referee, testHelper, buster) {
+(function (referee, testHelper, buster, sinon) {
     if (typeof require === "function" && typeof module === "object") {
         referee = require("../lib/referee");
         testHelper = require("./test-helper");

--- a/test/referee-test.js
+++ b/test/referee-test.js
@@ -3,7 +3,6 @@
         referee = require("../lib/referee");
         testHelper = require("./test-helper");
         buster = require("buster");
-        when = require("when");
     }
 
     var assert = buster.referee.assert;
@@ -180,17 +179,17 @@
             return tests({
                 pass: function (actual) {
                     return function () {
-                        return when(assertion.apply(this, [actual].concat(expected))).then(buster.assert.defined, buster.refute.defined);
+                        return Promise.resolve(assertion.apply(this, [actual].concat(expected))).then(buster.assert.defined, buster.refute.defined);
                     }
                 },
                 fail: function (actual) {
                     return function () {
-                        return when(assertion.apply(this, [actual].concat(expected))).then(buster.refute.defined, buster.assert.defined);
+                        return Promise.resolve(assertion.apply(this, [actual].concat(expected))).then(buster.refute.defined, buster.assert.defined);
                     }
                 },
                 yieldMsg: function (expectedMessage, actual) {
                     return function () {
-                        return when(assertion.apply(this, [actual].concat(expected))).then(buster.refute.defined, function (actualMessage) {
+                        return Promise.resolve(assertion.apply(this, [actual].concat(expected))).then(buster.refute.defined, function (actualMessage) {
                                 buster.assert.equals(actualMessage, "[" + type + "." + name + "] " + expectedMessage)
                             });
                     }
@@ -1723,4 +1722,4 @@
             });
         }
     });
-}(this.referee, this.testHelper, this.buster, this.when));
+}(this.referee, this.testHelper, this.buster));


### PR DESCRIPTION
This PR is progress for https://github.com/busterjs/buster/issues/463

It also:
* Replaces usages of `when` to expect a shim and use native `Promise` (introduced in https://github.com/busterjs/referee/pull/9, but never released)
* Runs tests on Travis via `grunt-buster` with phantom

Not sure whether to bump major or minor for release... keeping open for now.